### PR TITLE
Update readme for setup and logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ To view Apps Script pages:
 * **Embedding**: Embeds Apps Script web apps using iframes ([`page1.html`](website/public/page1.html), [`page2.html`](website/public/page2.html)).
 * **Custom Domain**: Uses Firebase Hosting for domain management.
 * **Dynamic Loading**: Load scripts dynamically using `org` URL parameter.
-* **Security**: Validates scripts via URL `org` and `sig` parameter using public key signature verification. See [`/util/crypto.js`](/util/crypto.js) for instructions to create your own public/private key pairs to sign your various script deployment ids.
+* **Security**: Validates scripts via URL `org` and `sig` parameter using public key signature verification. See [`util_crypto_org_sig/crypto.js`](util_crypto_org_sig/crypto.js) for instructions to create your own public/private key pairs to sign your various script deployment ids.
 
 * **Parent-Iframe Communication**:
 
@@ -60,6 +60,7 @@ Update placeholders in [`common.js`](website/public/js/common.js):
 * GTM dimensions (`g_dimensionsGTM`)
 
 Update domain settings (`g_host`) in [`logs.js`](website/functions/api/logs.js).
+Set the `ALLOWED_HOST` environment variable to the same domain when deploying functions so requests can be validated.
 
 ### Key Files
 
@@ -108,9 +109,11 @@ Use the github subdirectory or copy from https://docs.google.com/spreadsheets/d/
 
    ```sh
    cd website
+   cd functions && npm install && cd ..
    firebase deploy --only hosting
    firebase deploy --only functions
    ```
+   Cloud Functions require Node **22**, as specified in `functions/package.json`.
 
 2. **Deploy Apps Script**:
 


### PR DESCRIPTION
## Summary
- fix crypto helper reference
- clarify deploying functions (npm install, Node 22)
- document ALLOWED_HOST variable for logging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a088c17fc832780fc79f530a15dd9