### PR TITLE
Move crypto instructions to separate guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Shows a simple website with two pages, each one being a different apps script pa
 
 * **`website/`**: Parent website (Firebase or other hosts) managing Apps Script embedding, communication, and analytics.
 * **`google-apps-script/`**: Google Apps Script project with embedded page samples.
-* **`util-org-sig/`**: Crypto utility functions for the "org/sig" feature, with instructions to generate the public key, private key and for generating signatures ("sig") for different script ids, called organizations ("org").
+* **`util-org-sig/`**: Crypto utility functions for the "org/sig" feature. See `util-org-sig/readme.md` for key generation and signing instructions.
 
 ## Website Framework (`website/`)
 
@@ -39,7 +39,7 @@ Shows a simple website with two pages, each one being a different apps script pa
 * **Embedding**: Embeds Apps Script web apps using iframes ([`page1.html`](website/public/page1.html), [`page2.html`](website/public/page2.html)).
 * **Custom Domain**: Uses Firebase Hosting for domain management.
 * **Dynamic Loading**: Load scripts dynamically using `org` URL parameter.
-* **Security**: Validates scripts via URL `org` and `sig` parameter using public key signature verification. See [`util-org-sig/crypto.js`](util-org-sig/crypto.js) for instructions to create your own public/private key pairs to sign your various script deployment ids.
+* **Security**: Validates scripts via URL `org` and `sig` parameter using public key signature verification. See [`util-org-sig/readme.md`](util-org-sig/readme.md) for instructions to create your own public/private key pairs to sign your various script deployment ids.
 
 * **Parent-Iframe Communication**:
 

--- a/util-org-sig/crypto.js
+++ b/util-org-sig/crypto.js
@@ -1,16 +1,4 @@
 
-/**
- * Instructions for enabling multiple Script deployments using "org" and "sig":
- * 1 paste this code into the a browser console
- * 2. Run only once "await generatePublicAndPrivateKeys();"
- * 4. Important: store the generated private key securely. It should never be exposed in a frontend.
- * 5. Save both the public and private keys in this js file "g_keyPair". Do not publish this file in github.
- * 6. Update the public key in /website/public/js/common.js (g_publicKeyJwk)
- * 
- *  Every time you want to sign a new script id to generate its "org" parameter:
- *  Use the `signAndVerifyMessage` function with the script id (message) you want to sign,
- *  first making sure that g_keyPair contains the pair you initially generated.
- */
 let g_keyPair = {
     publicKey: {
         "crv": "P-256",

--- a/util-org-sig/readme.md
+++ b/util-org-sig/readme.md
@@ -1,0 +1,15 @@
+# Utility for the org/sig feature
+
+This folder contains helper code for generating ECDSA keys and signing script deployment ids. Follow these steps to create your own keys and signatures:
+
+1. Paste the contents of `crypto.js` into a browser console.
+2. Run once:
+
+   ```js
+   await generatePublicAndPrivateKeys();
+   ```
+
+   **Important:** store the generated private key securely. It should never be exposed in a frontend.
+3. Save both the public and private keys in `g_keyPair` inside `crypto.js`. Do not publish that file with real keys.
+4. Update the public key in `website/public/js/common.js` (`g_publicKeyJwk`).
+5. To generate an `org` parameter for a script deployment, use `signAndVerifyMessage` with the script id as the message. Ensure `g_keyPair` still contains the original key pair.

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -6,7 +6,7 @@ This directory contains the website that embeds the Apps Script web app via ifra
 
 - `public/` contains the static files served by Firebase Hosting. `public/js/common.js` drives the iframe integration logic.
 - `functions/` holds Firebase Cloud Functions (see `api/logs.js`) used for centralized logging.
-- `/util-org-sig/crypto.js` contains helper code to generate signing keys.
+- `util-org-sig/readme.md` contains helper code to generate signing keys.
 
 ## Coding Style
 

--- a/website/public/js/common.js
+++ b/website/public/js/common.js
@@ -23,7 +23,7 @@ const g_endpointPutLogs = "/api/logs/putLogs"; //CUSTOMIZE: endpoint for sending
 /**
  * Public key for verifying signatures.
 */
-//CUSTOMIZE: replace with your own public key generated from /util-org-sig/crypto.js
+//CUSTOMIZE: replace with your own public key generated from util-org-sig/readme.md
 const g_publicKeyJwk = {
     "kty": "EC",
     "crv": "P-256",


### PR DESCRIPTION
## Summary
- remove how-to comments from util-org-sig/crypto.js
- document org/sig key generation in util-org-sig/readme.md
- update references in README, AGENTS and client code

## Testing
- `npm test` *(fails: could not find package.json)*
- `cd website && npm test` *(fails: Missing script: "test")*
- `cd functions && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684ddac9bf188327ab73b77ba57bdb70